### PR TITLE
removed window.location.reload() in handleLikePost fxn - not needed

### DIFF
--- a/client/src/components/Post.js
+++ b/client/src/components/Post.js
@@ -54,7 +54,6 @@ const Post = ({ posts }) => {
                     postId
                 }
             });
-            window.location.reload();
 
         } catch (err) {
             console.error(err);


### PR DESCRIPTION
Don't need the window.location.reload() in Post.js when user likes post